### PR TITLE
Ratings

### DIFF
--- a/backend/src/controllers/offers.ts
+++ b/backend/src/controllers/offers.ts
@@ -248,7 +248,6 @@ export const rating: RequestHandler = async (req, res, next) => {
 				new: true,
 			}
 			);
-			res.json(updateRating);
 		}else{
 			const rateProduct = await offerModel.findByIdAndUpdate(offerId, {
 				$push: {
@@ -262,7 +261,6 @@ export const rating: RequestHandler = async (req, res, next) => {
 				new: true,
 			}
 			);
-			res.json(rateProduct);
 		}
 		const getallratings = await offerModel.findById(offerId);
 		let totalRating = getallratings.ratings.length;

--- a/backend/src/controllers/offers.ts
+++ b/backend/src/controllers/offers.ts
@@ -223,8 +223,6 @@ export const rating: RequestHandler = async (req, res, next) => {
 	const star = req.body.star;
 	const comment = req.body.comment;
 	const offerId = req.body.offerId;
-
-
 	try {
 		
 		if (!mongoose.isValidObjectId(offerId)) {

--- a/backend/src/controllers/offers.ts
+++ b/backend/src/controllers/offers.ts
@@ -221,6 +221,7 @@ export const searchOffer: RequestHandler = async (req, res, next) => {
 export const rating: RequestHandler = async (req, res, next) => {
 	const loggedUserId = req.session.userID;
 	const star = req.body.star;
+	const comment = req.body.comment;
 	const offerId = req.body.offerId;
 
 
@@ -242,7 +243,7 @@ export const rating: RequestHandler = async (req, res, next) => {
 				ratings: {$elemMatch:alreadyRated}
 			}, 
 			{
-				$set: {"ratings.$.star":star}
+				$set: {"ratings.$.star":star, "ratings.$.comment": comment},
 			},
 			{
 				new: true,
@@ -253,6 +254,7 @@ export const rating: RequestHandler = async (req, res, next) => {
 				$push: {
 					ratings:{
 						star: star,
+						comment: comment,
 						postedby: loggedUserId,
 					},
 				},

--- a/backend/src/controllers/offers.ts
+++ b/backend/src/controllers/offers.ts
@@ -221,7 +221,7 @@ export const searchOffer: RequestHandler = async (req, res, next) => {
 export const rating: RequestHandler = async (req, res, next) => {
 	const loggedUserId = req.session.userID;
 	const star = req.body.star;
-	const offerId = req.params.offerId;
+	const offerId = req.body.offerId;
 
 
 	try {

--- a/backend/src/models/offer.ts
+++ b/backend/src/models/offer.ts
@@ -11,6 +11,7 @@ const offerSchema = new Schema({
     ratings: [
         {
             star: {type: Number},
+            comment : {tyep: String},
             postedby: {type: Schema.Types.ObjectId, required: true},
         },
     ],

--- a/backend/src/models/offer.ts
+++ b/backend/src/models/offer.ts
@@ -8,6 +8,16 @@ const offerSchema = new Schema({
     imgURL: { type: String },
     price: { type : Number, required : true },
     category: {type: String,},
+    ratings: [
+        {
+            star: {type: Number},
+            postedby: {type: Schema.Types.ObjectId, required: true},
+        },
+    ],
+    totalrating:{
+        type: String,
+        default: 0,
+    },
 }, { timestamps: true });
 
 type Offer = InferSchemaType<typeof offerSchema>;

--- a/backend/src/routes/offers.ts
+++ b/backend/src/routes/offers.ts
@@ -10,5 +10,6 @@ router.get('/:offerId', OffersController.getOffer);
 router.post('/', OffersController.createOffer);
 router.patch('/:offerId', OffersController.updateOffer);
 router.delete('/:offerId', OffersController.deleteOffer);
+router.put('/rating', OffersController.rating)
 
 export default router;


### PR DESCRIPTION
## Description

This pull request adds a new feature that allows users to rate offers. The `rating` function has been added to the `OffersController`. Users can rate an offer by sending a PUT request to the `/api/offers/rating` endpoint with `star` , `comment`, and `offerId` in the request body. 

If the user has already rated the offer, their previous rating is updated. If not, a new rating is added to the offer. Additionally, the average rating for the offer is calculated and stored in the `totalrating` field of the offer.

## Changes Made


- Added the `rating` function to the `OffersController` to handle rating requests
- Extracted the `offerId` from the request bodyinstead of the request parameters in the `rating` function
- Updated the `offer` model to include a `totalrating` field to store the average rating for an offer and the 'ratings' field to store all ratings of an offer

## How to Test

1. Send a GET request to `/offers` to get a list of all offers.
2. Choose an offer to rate and note its `offerId`.
3. Send a PUT request to `api/offers/rating/` with the `offerId` in the URL parameter and the `star` , 'comment' , and 'offerId' in the request body. 
4. Send another GET request to `/offers/:offerId` to check that the offer's rating , comment, and `totalrating` field have been updated.

Here's an example: 

![image](https://user-images.githubusercontent.com/83848862/223896116-fbf55d0d-1c02-4ee1-9123-14fe2b9ac2f1.png)


## Checklist

- [x] Added the `rating` function to the `OffersController`
- [x] Extracted the `offerId` from the request body in the `rating` function
- [x] Updated the `offer` model to include a `totalrating` field
- [x] Added tests for the `rating` function
- [x] Updated the documentation to include the new `rating` endpoint and how to use it
